### PR TITLE
Deploy to our1 and initial ktools actions

### DIFF
--- a/.github/workflows/deploy_our1.yml
+++ b/.github/workflows/deploy_our1.yml
@@ -87,6 +87,3 @@ jobs:
         with:
           service_group: ${{ inputs.service_group }}
           environment: our1
-
-        
-      

--- a/.github/workflows/deploy_our1.yml
+++ b/.github/workflows/deploy_our1.yml
@@ -1,0 +1,92 @@
+name: Deploy to our1 using ktools
+
+on:
+  workflow_call:
+    inputs:
+      service_group:
+        required: true
+        type: string
+      branch:
+        required: false
+        type: string
+        default: ${{ github.ref_name }}
+      autodeploy_branches:
+        required: false
+        type: string
+        description: A list of branches that should trigger a deployment without the need for a valid commit message pattern
+        default: '["master", "main"]'
+
+
+jobs:
+  wait_for_build:
+    name: Wait for Build
+    runs-on: ubuntu-latest
+    if: >-
+      (
+        contains(github.event.head_commit.message, '#deployour1') ||
+        contains(github.event.head_commit.message, '#deploy') ||
+        contains(toJSON(inputs.autodeploy_branches), github.ref_name)
+      ) && 
+      ! contains(github.event.head_commit.message, '#nodeploy')
+    steps:
+
+      - name: Wait for Build
+        uses: bernardovale/action-wait-for-check@allowed-status
+        id: wait-for-build
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Jenkins
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          intervalSeconds: 5
+          timeoutSeconds: 1800
+          allowedStatus: success
+
+  deploy:
+    name: Deploy to Staging (our1)
+    needs: wait_for_build
+
+    runs-on: ubuntu-latest
+    if: >-
+      (
+        contains(github.event.head_commit.message, '#deployour1') ||
+        contains(github.event.head_commit.message, '#deploy') ||
+        contains(toJSON(inputs.autodeploy_branches), github.ref_name)
+      ) && 
+      ! contains(github.event.head_commit.message, '#nodeploy')
+
+    # Allow the job to fetch a GitHub ID token
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+
+      - name: Configure Credentials
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: "projects/70880649570/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "svc-github-ktools-action@kentik-continuous-delivery.iam.gserviceaccount.com"
+
+      - name: Show Current Status
+        uses: kentik/github-workflows/ktools/deploy/status@kt
+        with:
+          service_group: ${{ inputs.service_group }}
+          environment: our1
+          cleanup: false
+
+      - name: Deploy Service
+        uses: kentik/github-workflows/ktools/deploy/push@kt
+        with:
+          service_group: ${{ inputs.service_group }}
+          environment: our1
+          branch: ${{ inputs.branch }}
+          cleanup: false
+
+      - name: Show Status
+        uses: kentik/github-workflows/ktools/deploy/status@kt
+        with:
+          service_group: ${{ inputs.service_group }}
+          environment: our1
+
+        
+      

--- a/ktools/config/action.yml
+++ b/ktools/config/action.yml
@@ -1,0 +1,24 @@
+name: KTools Config
+description: 'Show Environment config of a ktools instance'
+inputs:
+  environment:
+    description: Environment 
+    required: true
+  cleanup:
+    description: |
+      Deletes the log subscription after executing the command. Set it to false if you plan to run other ktools commands in the same pipeline.
+    default: 'true'
+    required: false
+  subcommand:
+    default: config
+    description: action subcommand
+    required: false
+  operation:
+    default: show
+    description: operation of subcommand
+    required: false
+    
+    
+runs:
+  using: 'node16'
+  main: '../run.js'

--- a/ktools/deploy/push/action.yml
+++ b/ktools/deploy/push/action.yml
@@ -1,0 +1,31 @@
+name: KTools Deploy Service
+description: 'Deploy Kentik services using Github Actions'
+inputs:
+  environment:
+    description: Environment 
+    required: true
+  service_group:
+    description: Name of the service
+    required: true
+  branch:
+    description: 'Deploy service using image built from this branch. Append the build number to deploy a specific version. Example: `master.10`'
+    default: master
+    required: false
+  cleanup:
+    description: |
+      The log subscription won't be deleted if true. Set to `true` if you plan to run more kt commands in the pipeline. Set to false in the last command
+    default: 'true'
+    required: false
+  subcommand:
+    default: deploy
+    description: action subcommand
+    required: false
+  operation:
+    default: push
+    description: operation of subcommand
+    required: false
+    
+    
+runs:
+  using: 'node16'
+  main: '../../run.js'

--- a/ktools/deploy/restart/action.yml
+++ b/ktools/deploy/restart/action.yml
@@ -1,0 +1,27 @@
+name: KTools Restart Service
+description: 'Restart Kentik services using Github Actions'
+inputs:
+  environment:
+    description: Environment 
+    required: true
+  service_group:
+    description: Name of the service
+    required: true
+  cleanup:
+    description: |
+      The log subscription won't be deleted if true. Set to `true` if you plan to run more kt commands in the pipeline. Set to false in the last command
+    default: 'true'
+    required: false
+  subcommand:
+    default: deploy
+    description: action subcommand
+    required: false
+  operation:
+    default: restart
+    description: operation of subcommand
+    required: false
+    
+    
+runs:
+  using: 'node16'
+  main: '../../run.js'

--- a/ktools/deploy/status/action.yml
+++ b/ktools/deploy/status/action.yml
@@ -1,0 +1,27 @@
+name: KTools Service Status
+description: 'Show status of Kentik services using Github Actions'
+inputs:
+  environment:
+    description: Environment 
+    required: true
+  service_group:
+    description: Name of the service
+    required: true
+  cleanup:
+    description: |
+      Deletes the log subscription after executing the command. Set it to false if you plan to run other ktools commands in the same pipeline.
+    default: 'true'
+    required: false
+  subcommand:
+    default: deploy
+    description: action subcommand
+    required: false
+  operation:
+    default: status
+    description: operation of subcommand
+    required: false
+    
+    
+runs:
+  using: 'node16'
+  main: '../../run.js'

--- a/ktools/deploy/stop/action.yml
+++ b/ktools/deploy/stop/action.yml
@@ -1,0 +1,27 @@
+name: 'ktools deploy stop'
+description: 'Deploy Kentik services using Github Actions'
+inputs:
+  environment:
+    description: Environment 
+    required: true
+  service_group:
+    description: Name of the service
+    required: true
+  cleanup:
+    description: |
+      The log subscription won't be deleted if true. Set to `true` if you plan to run more kt commands in the pipeline. Set to false in the last command
+    default: 'true'
+    required: false
+  subcommand:
+    default: deploy
+    description: action subcommand
+    required: false
+  operation:
+    default: stop
+    description: operation of subcommand
+    required: false
+    
+    
+runs:
+  using: 'node16'
+  main: '../../run.js'

--- a/ktools/run.js
+++ b/ktools/run.js
@@ -1,0 +1,6 @@
+var childProcess = require('child_process');
+const { exit } = require('process');
+const fs = require('fs');
+const mainScript = `${__dirname}/main`
+const spawnSyncReturns = childProcess.spawnSync(mainScript, { stdio: 'inherit' })
+exit(spawnSyncReturns.status);


### PR DESCRIPTION
This PR introduces a workflow to deploy to our1 using ktools on github actions and some actions to use ktools directly from github.

To interact with ktools the `action` uses GCP Pubsub to send operation requests and streams output by subscribing to a reply topic. The js action is just a wrapper that runs a Go binary [from this repo](https://github.com/kentik/ktools-agent/blob/alpha/cmd/action/main.go).

It is important to mention that there's a pipeline to push the binary whenever we merge code on [ktools-agent](https://github.com/kentik/ktools-agent/blob/alpha/.github/workflows/build-action.yaml#L41).

This initial workflow allows users to configure a list of branches that should be deployed after Jenkins build. It uses a tiny little grammar to override its behavior matching string patterns on the commit message.

`#deploy` or `#deployour1` triggers a deploy even if the branch **is not configured** in the `autodeploy_branches`
`#nodeploy` skips the deploy even if the branch **is configured** in the `autodeploy_branches`


NOTE: Docs to follow in a next PR (docs.kntk.cloud)